### PR TITLE
Extend Concurrency API support

### DIFF
--- a/Source/Gauntlet/Asserts/BooleanAsserts.swift
+++ b/Source/Gauntlet/Asserts/BooleanAsserts.swift
@@ -91,6 +91,70 @@ public func XCTAssertTrue(
     failIfThrows(try then(), message: message, name: name, reporter: reporter, file: file, line: line)
 }
 
+/// Asserts that the expression is not `nil` and is `true`.
+///
+///     // Given
+///     func values() async -> [String: Bool] { ... }
+///
+///     // When, Then
+///     await XCTAwaitAssertTrue(await values()["some-key"]) {
+///         // Optionally perform additional conditional tests.
+///     }
+///
+/// - Note:
+///     This assert will fail if the result of the expression is `nil`.
+///
+/// - Parameters:
+///   - expression: An expression of type `Bool`.
+///   - message:    An optional description of the failure.
+///   - reporter:   The `FailureReporter` to report a failure to. The default reporter will report the failure with XCTest.
+///   - file:       The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line:       The line number on which failure occurred. Defaults to the line number on which this function was called.
+///   - then:       A closure to be called if the value is `true`. This can be used to run additional tests on the values.
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+public func XCTAwaitAssertTrue(
+    _ expression: @autoclosure () async throws -> Bool?,
+    _ message: @autoclosure () -> String = "",
+    reporter: FailureReporter = XCTestReporter.default,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    then: () async throws -> Void = { }) async
+{
+    let name = "XCTAwaitAssertTrue"
+    let result = await catchErrors(
+        in: expression,
+        message: message,
+        name: name,
+        reporter: reporter,
+        file: file,
+        line: line
+    )
+
+    guard case let .success(optionalValue) = result else { return }
+
+    guard let value = optionalValue else {
+        reporter.reportFailure(
+            description: "\(name) - (\"nil\") is not true\(suffix(from: message))",
+            file: file,
+            line: line
+        )
+
+        return
+    }
+
+    guard value == true else {
+        reporter.reportFailure(
+            description: "\(name) - (\"\(value)\") is not true\(suffix(from: message))",
+            file: file,
+            line: line
+        )
+
+        return
+    }
+
+    await failIfThrows(try await then(), message: message, name: name, reporter: reporter, file: file, line: line)
+}
+
 /// Asserts that the expression is not `nil` and is `false`.
 ///
 ///     // Given
@@ -133,7 +197,7 @@ public func XCTAssertFalse(
 
     guard let value = optionalValue else {
         reporter.reportFailure(
-            description: "\(name) - (\"nil\") is not true\(suffix(from: message))",
+            description: "\(name) - (\"nil\") is not false\(suffix(from: message))",
             file: file,
             line: line
         )
@@ -152,4 +216,68 @@ public func XCTAssertFalse(
     }
 
     failIfThrows(try then(), message: message, name: name, reporter: reporter, file: file, line: line)
+}
+
+/// Asserts that the expression is not `nil` and is `false`.
+///
+///     // Given
+///     func values() async -> [String: Bool] { ... }
+///
+///     // When, Then
+///     await XCTAwaitAssertFalse(await values()["some-key"]) {
+///         // Optionally perform additional conditional tests.
+///     }
+///
+/// - Note:
+///     This assert will fail if the result of the expression is `nil`.
+///
+/// - Parameters:
+///   - expression: An expression of type `Bool`.
+///   - message:    An optional description of the failure.
+///   - reporter:   The `FailureReporter` to report a failure to. The default reporter will report the failure with XCTest.
+///   - file:       The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line:       The line number on which failure occurred. Defaults to the line number on which this function was called.
+///   - then:       A closure to be called if the value is `false`. This can be used to run additional tests on the values.
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+public func XCTAwaitAssertFalse(
+    _ expression: @autoclosure () async throws -> Bool?,
+    _ message: @autoclosure () -> String = "",
+    reporter: FailureReporter = XCTestReporter.default,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    then: () async throws -> Void = { }) async
+{
+    let name = "XCTAwaitAssertFalse"
+    let result = await catchErrors(
+        in: expression,
+        message: message,
+        name: name,
+        reporter: reporter,
+        file: file,
+        line: line
+    )
+
+    guard case let .success(optionalValue) = result else { return }
+
+    guard let value = optionalValue else {
+        reporter.reportFailure(
+            description: "\(name) - (\"nil\") is not false\(suffix(from: message))",
+            file: file,
+            line: line
+        )
+
+        return
+    }
+
+    guard value == false else {
+        reporter.reportFailure(
+            description: "\(name) - (\"\(value)\") is not false\(suffix(from: message))",
+            file: file,
+            line: line
+        )
+
+        return
+    }
+
+    await failIfThrows(try await then(), message: message, name: name, reporter: reporter, file: file, line: line)
 }

--- a/Source/Gauntlet/Asserts/CustomAssertHelpers.swift
+++ b/Source/Gauntlet/Asserts/CustomAssertHelpers.swift
@@ -128,6 +128,36 @@ func failIfThrows(
     }
 }
 
+/// Evaluates an async throwing expression failing the test if an error is thrown. This is intended to be used with `then` closures in assert functions and the messaging
+/// is specific to that.
+///
+/// - Parameters:
+///   - expression: An expression that can throw asynchronously.
+///   - message:    A closure that returns a custom failure message passed from the user.
+///   - name:       The name of the assert calling. This will be added to the front of the failure message.
+///   - reporter:   The `FailureReporter` to report a failure to.
+///   - file:       The file in which the failure occurred.
+///   - line:       The line number on which the failure occurred.
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+func failIfThrows(
+    _ expression: @autoclosure () async throws -> Void,
+    message: () -> String,
+    name: String,
+    reporter: FailureReporter,
+    file: StaticString,
+    line: UInt) async
+{
+    do {
+        try await expression()
+    } catch {
+        reporter.reportFailure(
+            description: "\(name) - then closure threw error \"\(error)\"\(suffix(from: message))",
+            file: file,
+            line: line
+        )
+    }
+}
+
 /// This function will take the message autoclosure from a assert function and turn it in to a suffix for your failure
 /// message.
 ///

--- a/Source/Gauntlet/Asserts/OptionalAsserts.swift
+++ b/Source/Gauntlet/Asserts/OptionalAsserts.swift
@@ -76,3 +76,47 @@ public func XCTAssertNotNil<T>(
 
     failIfThrows(try then(value), message: message, name: name, reporter: reporter, file: file, line: line)
 }
+
+/// Asserts the value is not `nil`.
+///
+/// This function provides the same behavior as the `XCTAssertNotNil` function provided in `XCTest` but adds a closure that's called when the value is not `nil`, providing a strongly typed non-optional reference to the property.
+/// This simple addition makes tests around optional values much cleaner and easier to read by removing the need to add redundant conditional logic, guards that may prevent further tests from running, or optional chaining.
+///
+///     await XCTAwaitAssertNotNil(await getCurrentSession()) { session in
+///         XCTAssertEqual(userId, session.userId)
+///     }
+///
+/// - Parameters:
+///   - expression: An expression of type `T?` to compare against `nil`.
+///   - message:    An optional description of the failure.
+///   - reporter:   The `FailureReporter` to report a failure to. The default reporter will report the failure with XCTest.
+///   - file:       The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line:       The line number on which failure occurred. Defaults to the line number on which this function was called.
+///   - then:       A closure to be called if the `value` is not `nil`. This can be used to run additional tests on the value.
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+public func XCTAwaitAssertNotNil<T: Sendable>(
+    _ expression: @autoclosure () async throws -> T?,
+    _ message: @autoclosure () -> String = "",
+    reporter: FailureReporter = XCTestReporter.default,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    then: (T) async throws -> Void = { _ in })
+async {
+    let name = "XCTAwaitAssertNotNil"
+    let result = await catchErrors(
+        in: expression,
+        message: message,
+        name: name,
+        reporter: reporter,
+        file: file,
+        line: line
+    )
+
+    guard case let .success(optionalValue) = result else { return }
+    guard let value = optionalValue else {
+        reporter.reportFailure(description: "\(name)\(suffix(from: message))", file: file, line: line)
+        return
+    }
+
+    await failIfThrows(try await then(value), message: message, name: name, reporter: reporter, file: file, line: line)
+}

--- a/Tests/GauntletTests/Asserts/ThrowsAssertTests.swift
+++ b/Tests/GauntletTests/Asserts/ThrowsAssertTests.swift
@@ -63,7 +63,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var thrownError: EquatableError?
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), ofType: EquatableError.self, reporter: mock) { error in
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), ofType: EquatableError.self, reporter: mock) { error in
             completionCalled = true
             thrownError = error
         }
@@ -99,7 +99,7 @@ class ThrowAssertsTestCase: XCTestCase {
         let thrower = Thrower(error: errorToThrow)
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), ofType: EquatableError.self, reporter: mock)
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), ofType: EquatableError.self, reporter: mock)
 
         // Then
         XCTAssertNil(mock.message)
@@ -133,7 +133,7 @@ class ThrowAssertsTestCase: XCTestCase {
         let mock = FailMock()
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             "no throw",
             ofType: EquatableError.self,
             "custom message",
@@ -143,7 +143,32 @@ class ThrowAssertsTestCase: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(mock.message, "XCTAssertThrowsError - expression did not throw an error - custom message")
+        XCTAssertEqual(mock.message, "XCTAwaitAssertThrowsError - expression did not throw an error - custom message")
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorOfTypeWithNonThrowingExpressionWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - expression did not throw an error - \(message)
+        """
+        // Given
+        let mock = FailMock()
+
+        // When
+        await XCTAssertThrowsError(
+            "no throw",
+            ofType: EquatableError.self,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123
+        )
+
+        // Then
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -185,7 +210,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             try await thrower.asyncThrow(),
             ofType: EquatableError.self,
             "custom message",
@@ -201,8 +226,39 @@ class ThrowAssertsTestCase: XCTestCase {
         XCTAssertFalse(completionCalled)
         XCTAssertEqual(
             mock.message,
-            "XCTAssertThrowsError - error of type WrongError is not expected type EquatableError - custom message"
+            "XCTAwaitAssertThrowsError - error of type WrongError is not expected type EquatableError - custom message"
         )
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorOfTypeWithIncorrectTypeWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - error of type WrongError is not expected type EquatableError - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        let thrower = Thrower(error: WrongError())
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            try await thrower.asyncThrow(),
+            ofType: EquatableError.self,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: { _ in
+                completionCalled = true
+            }
+        )
+
+        // Then
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -242,7 +298,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             try await thrower.asyncThrow(),
             ofType: EquatableError.self,
             "custom message",
@@ -257,7 +313,39 @@ class ThrowAssertsTestCase: XCTestCase {
 
         // Then
         XCTAssertTrue(completionCalled)
-        XCTAssertEqual(mock.message, #"XCTAssertThrowsError - then closure threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.message, #"XCTAwaitAssertThrowsError - then closure threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorOfTypeWithThrowingThenWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - then closure threw error "Mock Error" - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        let thrower = Thrower(error: EquatableError.someError)
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            try await thrower.asyncThrow(),
+            ofType: EquatableError.self,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: { _ in
+                completionCalled = true
+                throw MockError()
+            }
+        )
+
+        // Then
+        XCTAssertTrue(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -292,7 +380,7 @@ class ThrowAssertsTestCase: XCTestCase {
         let thrower = Thrower(error: MockError())
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), ofType: MockError.self) { _ in
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), ofType: MockError.self) { _ in
             throwingAutoclosure(try functionThatCanThrow())
             completionCalled = true
         }
@@ -331,7 +419,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError, reporter: mock) {
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError, reporter: mock) {
             completionCalled = true
         }
 
@@ -365,7 +453,7 @@ class ThrowAssertsTestCase: XCTestCase {
         let thrower = Thrower(error: errorToThrow)
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError, reporter: mock)
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError, reporter: mock)
 
         // Then
         XCTAssertNil(mock.message)
@@ -405,7 +493,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             "no throw",
             equalTo: EquatableError.someError,
             "custom message",
@@ -419,7 +507,37 @@ class ThrowAssertsTestCase: XCTestCase {
 
         // Then
         XCTAssertFalse(completionCalled)
-        XCTAssertEqual(mock.message, "XCTAssertThrowsError - expression did not throw an error - custom message")
+        XCTAssertEqual(mock.message, "XCTAwaitAssertThrowsError - expression did not throw an error - custom message")
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorEqualToWithNonThrowingExpressionWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - expression did not throw an error - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            "no throw",
+            equalTo: EquatableError.someError,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: {
+                completionCalled = true
+            }
+        )
+
+        // Then
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -461,7 +579,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             try await thrower.asyncThrow(),
             equalTo: EquatableError.someError,
             "custom message",
@@ -477,8 +595,39 @@ class ThrowAssertsTestCase: XCTestCase {
         XCTAssertFalse(completionCalled)
         XCTAssertEqual(
             mock.message,
-            "XCTAssertThrowsError - error of type WrongError is not expected type EquatableError - custom message"
+            "XCTAwaitAssertThrowsError - error of type WrongError is not expected type EquatableError - custom message"
         )
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorEqualToWithIncorrectTypeWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - error of type WrongError is not expected type EquatableError - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        let thrower = Thrower(error: WrongError())
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            try await thrower.asyncThrow(),
+            equalTo: EquatableError.someError,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: {
+                completionCalled = true
+            }
+        )
+
+        // Then
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -520,7 +669,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             try await thrower.asyncThrow(),
             equalTo: EquatableError.someOtherError,
             "custom message",
@@ -536,8 +685,39 @@ class ThrowAssertsTestCase: XCTestCase {
         XCTAssertFalse(completionCalled)
         XCTAssertEqual(
             mock.message,
-            "XCTAssertThrowsError - (\"Some Error\") is not equal to (\"Some Other Error\") - custom message"
+            "XCTAwaitAssertThrowsError - (\"Some Error\") is not equal to (\"Some Other Error\") - custom message"
         )
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorEqualToWithUnequalErrorWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - ("Some Error") is not equal to ("Some Other Error") - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        let thrower = Thrower(error: EquatableError.someError)
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            try await thrower.asyncThrow(),
+            equalTo: EquatableError.someOtherError,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: {
+                completionCalled = true
+            }
+        )
+
+        // Then
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -577,7 +757,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertThrowsError(
+        await XCTAwaitAssertThrowsError(
             try await thrower.asyncThrow(),
             equalTo: EquatableError.someError,
             "custom message",
@@ -592,7 +772,39 @@ class ThrowAssertsTestCase: XCTestCase {
 
         // Then
         XCTAssertTrue(completionCalled)
-        XCTAssertEqual(mock.message, #"XCTAssertThrowsError - then closure threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.message, #"XCTAwaitAssertThrowsError - then closure threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.file, "some file")
+        XCTAssertEqual(mock.line, 123)
+    }
+
+    @available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+    func testAsyncAssertThrowsErrorEqualToWithThrowingThenWhenCallingTheDeprecatedFunction() async {
+        let message = "XCTAssertThrowsError calls XCTAwaitAssertThrowsError"
+        let expectedMessage = """
+        XCTAwaitAssertThrowsError - then closure threw error "Mock Error" - \(message)
+        """
+        // Given
+        let mock = FailMock()
+        let thrower = Thrower(error: EquatableError.someError)
+        var completionCalled = false
+
+        // When
+        await XCTAssertThrowsError(
+            try await thrower.asyncThrow(),
+            equalTo: EquatableError.someError,
+            message,
+            reporter: mock,
+            file: "some file",
+            line: 123,
+            then: {
+                completionCalled = true
+                throw MockError()
+            }
+        )
+
+        // Then
+        XCTAssertTrue(completionCalled)
+        XCTAssertEqual(mock.message, expectedMessage)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -627,7 +839,7 @@ class ThrowAssertsTestCase: XCTestCase {
         let thrower = Thrower(error: EquatableError.someError)
 
         // When
-        await XCTAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError) {
+        await XCTAwaitAssertThrowsError(try await thrower.asyncThrow(), equalTo: EquatableError.someError) {
             throwingAutoclosure(try functionThatCanThrow())
             completionCalled = true
         }
@@ -670,7 +882,7 @@ class ThrowAssertsTestCase: XCTestCase {
         func nonThrowingAsyncFunction () async throws -> Int { 2 }
 
         // When
-        await XCTAssertNoThrow(try await nonThrowingAsyncFunction(), reporter: mock) { value in
+        await XCTAwaitAssertNoThrow(try await nonThrowingAsyncFunction(), reporter: mock) { value in
             valuePassedToCompletion = value
             completionCalled = true
         }
@@ -711,13 +923,19 @@ class ThrowAssertsTestCase: XCTestCase {
         func throwingAsyncFunction () async throws -> Int { throw MockError() }
 
         // When
-        await XCTAssertNoThrow(try await throwingAsyncFunction(), "custom message", reporter: mock, file: "some file", line: 123) { _ in
+        await XCTAwaitAssertNoThrow(
+            try await throwingAsyncFunction(),
+            "custom message",
+            reporter: mock,
+            file: "some file",
+            line: 123
+        ) { _ in
             completionCalled = true
         }
 
         // Then
         XCTAssertFalse(completionCalled)
-        XCTAssertEqual(mock.message, #"XCTAssertNoThrow - threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.message, #"XCTAwaitAssertNoThrow - threw error "Mock Error" - custom message"#)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -751,14 +969,20 @@ class ThrowAssertsTestCase: XCTestCase {
         func nonThrowingAsyncFunction () async throws -> Int { 2 }
 
         // When
-        await XCTAssertNoThrow(try await nonThrowingAsyncFunction(), "custom message", reporter: mock, file: "some file", line: 123) { _ in
+        await XCTAwaitAssertNoThrow(
+            try await nonThrowingAsyncFunction(),
+            "custom message",
+            reporter: mock,
+            file: "some file",
+            line: 123
+        ) { _ in
             completionCalled = true
             throw MockError()
         }
 
         // Then
         XCTAssertTrue(completionCalled)
-        XCTAssertEqual(mock.message, #"XCTAssertNoThrow - then closure threw error "Mock Error" - custom message"#)
+        XCTAssertEqual(mock.message, #"XCTAwaitAssertNoThrow - then closure threw error "Mock Error" - custom message"#)
         XCTAssertEqual(mock.file, "some file")
         XCTAssertEqual(mock.line, 123)
     }
@@ -793,7 +1017,7 @@ class ThrowAssertsTestCase: XCTestCase {
         var completionCalled = false
 
         // When
-        await XCTAssertNoThrow(try await nonThrowingAsyncFunction()) { _ in
+        await XCTAwaitAssertNoThrow(try await nonThrowingAsyncFunction()) { _ in
             throwingAutoclosure(try functionThatCanThrow())
             completionCalled = true
         }

--- a/Tests/GauntletTests/Utility/ThrowingHelpers.swift
+++ b/Tests/GauntletTests/Utility/ThrowingHelpers.swift
@@ -29,3 +29,9 @@ import Foundation
 
 func throwingAutoclosure(_ expression: @autoclosure () throws -> Void) {}
 func functionThatCanThrow() throws {}
+
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+func asyncThrowingAutoclosure(_ expression: @autoclosure () async throws -> Void) async {}
+
+@available(iOS 13.0.0, tvOS 13.0.0, macOS 10.15.0, *)
+func asyncFunctionThatCanThrow() async throws {}


### PR DESCRIPTION
### What:

CHANGES:

+ Add `XCTAwaitAssertEqual`.
+ Add `XCTAwaitAssertNotNil`.
+ Add `XCTAwaitAssertFalse` and `XCTAwaitAssertTrue`.

DEPRECATED:

+ `XCTAssertNoThrow` in favor of `XCTAwaitAssertNoThrow`.
+ `XCTAssertThrowsError` in favor of `XCTAwaitAssertThrowsError`.

### Why:

+ To provide assertion functions for the **Concurrency API**.

### How:

+ Extending the support to `@Sendable` functions and adding consistent naming for the functions added.