### PR TITLE
Updating sign-off action to use shared flows

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: sign off
-        uses: krogertechnology/sign-off@v1.0.1
+        uses: krogerco/Shared-CI-Workflow-iOS/.github/workflows/qa.yml@feature/initial
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What:
Updating sign-off to point to shared actions.

### Why:
Because I like to share. That and this will make it usable in the open source projects.

### How:
I'm just pointing to the yaml file that fires off the action.

### Testing Notes
This should still work as expected. I'm just pointing to a new place.
