### PR TITLE
Add FailureReason operators

### DIFF
--- a/Source/Gauntlet/Operators/BoolOperators.swift
+++ b/Source/Gauntlet/Operators/BoolOperators.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 
-extension Assertion where Value == Bool {
+extension Assertion<Bool> {
     /// Asserts that the value is `true`.
     @discardableResult
     public func isTrue(line: Int = #line) -> Assertion<Void> {

--- a/Source/Gauntlet/Operators/FailureReasonOperators.swift
+++ b/Source/Gauntlet/Operators/FailureReasonOperators.swift
@@ -55,7 +55,6 @@ extension Assertion<FailureReason> {
 
             case .thrownError(let error):
                 return .pass(error)
-
             }
         }
     }

--- a/Source/Gauntlet/Operators/FailureReasonOperators.swift
+++ b/Source/Gauntlet/Operators/FailureReasonOperators.swift
@@ -3,7 +3,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/Gauntlet/Operators/FailureReasonOperators.swift
+++ b/Source/Gauntlet/Operators/FailureReasonOperators.swift
@@ -1,0 +1,62 @@
+//
+//  FailureReasonOperators.swift
+//
+//  MIT License
+//
+//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+
+extension Assertion<FailureReason> {
+
+    /// Asserts that the ``FailureReason`` is a `message`, providing the message string.
+    ///
+    /// - Returns: An ``Assertion`` containing the message string.
+    @discardableResult
+    public func isMessage(line: Int = #line) -> Assertion<String> {
+        evaluate(name: "isMessage", lineNumber: line) { reason in
+            switch reason {
+            case .message(let message):
+                return .pass(message)
+
+            case .thrownError(let error):
+                return .fail(message: "FailureReason is thrownError: \(error)")
+            }
+        }
+    }
+
+    /// Asserts that the ``FailureReason`` is a `thrownError`, providing the error.
+    ///
+    /// - Returns: An ``Assertion`` containing the error.
+    @discardableResult
+    public func isThrownError(line: Int = #line) -> Assertion<Error> {
+        evaluate(name: "isThrownError", lineNumber: line) { reason in
+            switch reason {
+            case .message(let message):
+                return .fail(message: "FailureReason is message: \(message)")
+
+            case .thrownError(let error):
+                return .pass(error)
+
+            }
+        }
+    }
+}

--- a/Source/Gauntlet/Operators/TypeOperators.swift
+++ b/Source/Gauntlet/Operators/TypeOperators.swift
@@ -34,8 +34,8 @@ extension Assertion {
     ///
     /// - Returns: An ``Assertion`` containing the value cast to the specified type.
     @discardableResult
-    public func isType<T>(_ expectedType: T.Type, line: Int = #line) -> Assertion<T> {
-        evaluate(name: "isType", lineNumber: line) { value in
+    public func isOfType<T>(_ expectedType: T.Type, line: Int = #line) -> Assertion<T> {
+        evaluate(name: "isOfType", lineNumber: line) { value in
             if let castValue = value as? T {
                 return .pass(castValue)
             }

--- a/Tests/GauntletTests/Operators/BoolOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/BoolOperatorsTests.swift
@@ -49,7 +49,8 @@ class BoolAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isTrue", expectedLine: expectedLine)
-            .isEqualTo(.message("value is false"))
+            .isMessage()
+            .isEqualTo("value is false")
     }
 
     func testIsFalseSuccess() {
@@ -73,6 +74,7 @@ class BoolAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isFalse", expectedLine: expectedLine)
-            .isEqualTo(.message("value is true"))
+            .isMessage()
+            .isEqualTo("value is true")
     }
 }

--- a/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
@@ -54,7 +54,8 @@ class CollectionAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isEmpty", expectedLine: expectedLine)
-            .isEqualTo(.message("The collection has 1 item"))
+            .isMessage()
+            .isEqualTo("The collection has 1 item")
     }
 
     func testIsEmptyFailureMultipleItems() {
@@ -68,7 +69,8 @@ class CollectionAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isEmpty", expectedLine: expectedLine)
-            .isEqualTo(.message("The collection has 3 items"))
+            .isMessage()
+            .isEqualTo("The collection has 3 items")
     }
 
     // MARK: - isNotEmpty
@@ -98,7 +100,8 @@ class CollectionAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isNotEmpty", expectedLine: expectedLine)
-            .isEqualTo(.message("The collection is empty"))
+            .isMessage()
+            .isEqualTo("The collection is empty")
     }
 
     // MARK: - hasCount
@@ -128,6 +131,7 @@ class CollectionAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "hasCount", expectedLine: expectedLine)
-            .isEqualTo(.message("Count of 2 is not equal to the expected count 5"))
+            .isMessage()
+            .isEqualTo("Count of 2 is not equal to the expected count 5")
     }
 }

--- a/Tests/GauntletTests/Operators/EqualWithAccuracyOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/EqualWithAccuracyOperatorsTests.swift
@@ -56,7 +56,8 @@ class EqualWithAccuracyAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isEqualTo(, accuracy)", expectedLine: expectedLine)
-            .isEqualTo(.message("4 is not equal to the expected value 1. Accuracy: 2"))
+            .isMessage()
+            .isEqualTo("4 is not equal to the expected value 1. Accuracy: 2")
     }
 
     /// Runs a number of live assertions to validate the success behavior with a variety of values.
@@ -133,7 +134,8 @@ class EqualWithAccuracyAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isNotEqualTo(, accuracy)", expectedLine: expectedLine)
-            .isEqualTo(.message("4 is equal to the expected value 3. Accuracy: 2"))
+            .isMessage()
+            .isEqualTo("4 is equal to the expected value 3. Accuracy: 2")
     }
 
     /// Runs a number of live assertions to validate the success behavior with a variety of values.

--- a/Tests/GauntletTests/Operators/EquatableOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/EquatableOperatorsTests.swift
@@ -95,7 +95,8 @@ class EquatableAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isNotEqualTo", expectedLine: expectedLine)
-            .isEqualTo(.message(#""57" is equal to the specified value"#))
+            .isMessage()
+            .isEqualTo(#""57" is equal to the specified value"#)
     }
 
     func testLiveIsNotEqual() {

--- a/Tests/GauntletTests/Operators/FailureReasonOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/FailureReasonOperatorsTests.swift
@@ -3,7 +3,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/GauntletTests/Operators/FailureReasonOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/FailureReasonOperatorsTests.swift
@@ -1,0 +1,106 @@
+//
+//  FailureReasonOperatorsTests.swift
+//
+//  MIT License
+//
+//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+@testable import Gauntlet
+import XCTest
+
+class FailureReasonOperatorsTestCase: XCTestCase {
+    func testIsMessagePass() {
+        // Given
+        let expectedMessage = "some messge"
+        let expectedLine = 321
+
+        // When
+        let assertion = TestAnAssertion(on: FailureReason.message(expectedMessage)).isMessage(line: expectedLine)
+
+        // Then
+        switch assertion.result {
+        case .pass(let message):
+            XCTAssertEqual(message, expectedMessage)
+        case .fail(let reason):
+            XCTFail("isMessage result is a fail: \(reason)")
+        }
+
+        XCTAssertEqual(assertion.name, "isMessage")
+        XCTAssertEqual(assertion.lineNumber, expectedLine)
+    }
+
+    func testIsMessageFail() {
+        // Given
+        let expectedLine = 123
+
+        // When
+        let assertion = TestAnAssertion(on: FailureReason.thrownError(MockError.someOtherError)).isMessage(line: expectedLine)
+
+        // Then
+        if case let .fail(reason) = assertion.result, case let .message(message) = reason {
+            XCTAssertEqual(message, "FailureReason is thrownError: Some Other Error")
+        } else {
+            XCTFail("isMessage result isn't a fail with a message")
+        }
+
+        XCTAssertEqual(assertion.name, "isMessage")
+        XCTAssertEqual(assertion.lineNumber, expectedLine)
+    }
+
+    func testIsThrownErrorPass() {
+        // Given
+        let expectedError = MockError.someError
+        let expectedLine = 321
+
+        // When
+        let assertion = TestAnAssertion(on: FailureReason.thrownError(expectedError)).isThrownError(line: expectedLine)
+
+        // Then
+        switch assertion.result {
+        case .pass(let error):
+            XCTAssert(error is MockError, "The value provided in the error should be the MockError")
+        case .fail(let reason):
+            XCTFail("isThrownError result is a fail: \(reason)")
+        }
+
+        XCTAssertEqual(assertion.name, "isThrownError")
+        XCTAssertEqual(assertion.lineNumber, expectedLine)
+    }
+
+    func testIsThrownErrorFail() {
+        // Given
+        let expectedLine = 123
+
+        // When
+        let assertion = TestAnAssertion(on: FailureReason.message("some message")).isThrownError(line: expectedLine)
+
+        // Then
+        if case let .fail(reason) = assertion.result, case let .message(message) = reason {
+            XCTAssertEqual(message, "FailureReason is message: some message")
+        } else {
+            XCTFail("isThrownError result isn't a fail with a message")
+        }
+
+        XCTAssertEqual(assertion.name, "isThrownError")
+        XCTAssertEqual(assertion.lineNumber, expectedLine)
+    }
+}

--- a/Tests/GauntletTests/Operators/OptionalOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/OptionalOperatorsTests.swift
@@ -56,7 +56,8 @@ class OptionalAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isNotNil", expectedLine: line)
-            .isEqualTo(.message("value is nil"))
+            .isMessage()
+            .isEqualTo("value is nil")
     }
 
     // MARK: - isNil
@@ -85,6 +86,7 @@ class OptionalAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isNil", expectedLine: line)
-            .isEqualTo(.message("value is not nil"))
+            .isMessage()
+            .isEqualTo("value is not nil")
     }
 }

--- a/Tests/GauntletTests/Operators/ResultOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/ResultOperatorsTests.swift
@@ -54,7 +54,8 @@ class ResultAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isSuccess", expectedLine: expectedLine)
-            .isEqualTo(.message("Result is a failure: Some Error"))
+            .isMessage()
+            .isEqualTo("Result is a failure: Some Error")
     }
 
     func testIsFailureWithFailure() {
@@ -83,6 +84,7 @@ class ResultAssertsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "isFailure", expectedLine: expectedLine)
-            .isEqualTo(.message("Result is a success"))
+            .isMessage()
+            .isEqualTo("Result is a success")
     }
 }

--- a/Tests/GauntletTests/Operators/ThenOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/ThenOperatorsTests.swift
@@ -61,7 +61,10 @@ class ThenAssertionsTestCase: XCTestCase {
 
         Assert(that: failure.name).isEqualTo("then")
         Assert(that: failure.lineNumber).isEqualTo(line)
-        Assert(that: failure.reason).isEqualTo(.thrownError(thrownError))
+        Assert(that: failure.reason)
+            .isThrownError()
+            .isType(MockError.self)
+            .isEqualTo(thrownError)
     }
 
     func testThenOnFailingAssertion() {

--- a/Tests/GauntletTests/Operators/ThenOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/ThenOperatorsTests.swift
@@ -63,7 +63,7 @@ class ThenAssertionsTestCase: XCTestCase {
         Assert(that: failure.lineNumber).isEqualTo(line)
         Assert(that: failure.reason)
             .isThrownError()
-            .isType(MockError.self)
+            .isOfType(MockError.self)
             .isEqualTo(thrownError)
     }
 

--- a/Tests/GauntletTests/Operators/ThrowingOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/ThrowingOperatorsTests.swift
@@ -53,7 +53,9 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "doesNotThrow", expectedLine: expectedLine)
-            .isEqualTo(.thrownError(MockError.someError))
+            .isThrownError()
+            .isType(MockError.self)
+            .isEqualTo(.someError)
     }
 
     func testThrowsError() {
@@ -82,7 +84,8 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "throwsError", expectedLine: expectedLine)
-            .isEqualTo(.message(#"Expression did not throw. Returned "some value""#))
+            .isMessage()
+            .isEqualTo(#"Expression did not throw. Returned "some value""#)
     }
 
     // MARK: - Async
@@ -115,7 +118,9 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "doesNotThrow", expectedLine: expectedLine)
-            .isEqualTo(.thrownError(MockError.someError))
+            .isThrownError()
+            .isType(MockError.self)
+            .isEqualTo(.someError)
     }
 
     func testAsyncThrowsError() async {
@@ -146,6 +151,7 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didFail(expectedName: "throwsError", expectedLine: expectedLine)
-            .isEqualTo(.message(#"Expression did not throw. Returned "some value""#))
+            .isMessage()
+            .isEqualTo(#"Expression did not throw. Returned "some value""#)
     }
 }

--- a/Tests/GauntletTests/Operators/ThrowingOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/ThrowingOperatorsTests.swift
@@ -54,7 +54,7 @@ class ThrowingAssertionsTestCase: XCTestCase {
         Assert(that: assertion)
             .didFail(expectedName: "doesNotThrow", expectedLine: expectedLine)
             .isThrownError()
-            .isType(MockError.self)
+            .isOfType(MockError.self)
             .isEqualTo(.someError)
     }
 
@@ -69,7 +69,7 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didPass(expectedName: "throwsError", expectedLine: expectedLine)
-            .isType(MockError.self)
+            .isOfType(MockError.self)
             .isEqualTo(.someError)
     }
 
@@ -119,7 +119,7 @@ class ThrowingAssertionsTestCase: XCTestCase {
         Assert(that: assertion)
             .didFail(expectedName: "doesNotThrow", expectedLine: expectedLine)
             .isThrownError()
-            .isType(MockError.self)
+            .isOfType(MockError.self)
             .isEqualTo(.someError)
     }
 
@@ -135,7 +135,7 @@ class ThrowingAssertionsTestCase: XCTestCase {
         // Then
         Assert(that: assertion)
             .didPass(expectedName: "throwsError", expectedLine: expectedLine)
-            .isType(MockError.self)
+            .isOfType(MockError.self)
             .isEqualTo(.someError)
     }
 

--- a/Tests/GauntletTests/Operators/TypeOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/TypeOperatorsTests.swift
@@ -35,11 +35,11 @@ class TypeAssertionsTestCase: XCTestCase {
         let line = 345
 
         // When
-        let assertion = TestAnAssertion(on: protocolValue).isType(SomeConformingType.self, line: line)
+        let assertion = TestAnAssertion(on: protocolValue).isOfType(SomeConformingType.self, line: line)
 
         // Then
         Assert(that: assertion)
-            .didPass(expectedName: "isType", expectedLine: line)
+            .didPass(expectedName: "isOfType", expectedLine: line)
             .isEqualTo(SomeConformingType(value: expectedValue))
     }
 
@@ -49,13 +49,13 @@ class TypeAssertionsTestCase: XCTestCase {
         let line = 543
 
         // When
-        let assertion = TestAnAssertion(on: value).isType(SomeProtocol.self, line: line)
+        let assertion = TestAnAssertion(on: value).isOfType(SomeProtocol.self, line: line)
 
         // Then
         let expectedMessage = #"Value of type SomeNonConformingType does not conform to expected type SomeProtocol"#
 
         Assert(that: assertion)
-            .didFail(expectedName: "isType", expectedLine: line)
+            .didFail(expectedName: "isOfType", expectedLine: line)
             .isEqualTo(.message(expectedMessage))
     }
 }


### PR DESCRIPTION
### What:
This adds two operators for `FailureReason`, `isMessage` and `isThrownError` to validate both cases of the enum and provides the associated values in the returned assert.

### Why:
Previously operator tests would use `isEqual` and lean on the Equatable conformance, but this felt a bit clumsy and undiscoverable. Having operators for the reason feels like it improves reading/writing operator tests and feels more consistent with the new Gauntlet API.

### Testing Notes
Tests for the new operators use XCTest directly as these become part of the Gauntlet core.
