### PR TITLE
Demo App Updates

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -8,8 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		252FFA6929CA649D0010C984 /* GauntletLegacy in Frameworks */ = {isa = PBXBuildFile; productRef = 252FFA6829CA649D0010C984 /* GauntletLegacy */; };
+		252FFA6C29CB93690010C984 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA6B29CB93690010C984 /* Product.swift */; };
+		252FFA6E29CB948C0010C984 /* ProductError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA6D29CB948C0010C984 /* ProductError.swift */; };
+		252FFA7029CB9C130010C984 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA6F29CB9C130010C984 /* Cart.swift */; };
+		252FFA7229CBA3E50010C984 /* ProductService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA7129CBA3E50010C984 /* ProductService.swift */; };
+		252FFA7529CBAE230010C984 /* ProductServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA7329CBACD00010C984 /* ProductServiceTests.swift */; };
+		252FFA7829CBB2530010C984 /* CartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FFA7629CBB2420010C984 /* CartTests.swift */; };
 		67F19643284970E500008D82 /* DemoAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F19642284970E500008D82 /* DemoAppApp.swift */; };
-		67F19645284970E500008D82 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F19644284970E500008D82 /* ContentView.swift */; };
 		67F19654284970E500008D82 /* DemoAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F19653284970E500008D82 /* DemoAppTests.swift */; };
 		67F19670284971B100008D82 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 67F1966D284971B100008D82 /* Assets.xcassets */; };
 		67F19671284971B100008D82 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 67F1966F284971B100008D82 /* Preview Assets.xcassets */; };
@@ -27,9 +32,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		252FFA6B29CB93690010C984 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		252FFA6D29CB948C0010C984 /* ProductError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductError.swift; sourceTree = "<group>"; };
+		252FFA6F29CB9C130010C984 /* Cart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
+		252FFA7129CBA3E50010C984 /* ProductService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductService.swift; sourceTree = "<group>"; };
+		252FFA7329CBACD00010C984 /* ProductServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductServiceTests.swift; sourceTree = "<group>"; };
+		252FFA7629CBB2420010C984 /* CartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartTests.swift; sourceTree = "<group>"; };
 		67F1963F284970E500008D82 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		67F19642284970E500008D82 /* DemoAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppApp.swift; sourceTree = "<group>"; };
-		67F19644284970E500008D82 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		67F1964F284970E500008D82 /* DemoAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		67F19653284970E500008D82 /* DemoAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppTests.swift; sourceTree = "<group>"; };
 		67F1966D284971B100008D82 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -56,6 +66,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		252FFA6A29CB92010010C984 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				252FFA6B29CB93690010C984 /* Product.swift */,
+				252FFA6D29CB948C0010C984 /* ProductError.swift */,
+				252FFA6F29CB9C130010C984 /* Cart.swift */,
+				252FFA7129CBA3E50010C984 /* ProductService.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		67F19636284970E400008D82 = {
 			isa = PBXGroup;
 			children = (
@@ -80,7 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				67F19642284970E500008D82 /* DemoAppApp.swift */,
-				67F19644284970E500008D82 /* ContentView.swift */,
+				252FFA6A29CB92010010C984 /* Models */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -89,6 +110,8 @@
 			isa = PBXGroup;
 			children = (
 				67F19653284970E500008D82 /* DemoAppTests.swift */,
+				252FFA7329CBACD00010C984 /* ProductServiceTests.swift */,
+				252FFA7629CBB2420010C984 /* CartTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -244,8 +267,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				67F19645284970E500008D82 /* ContentView.swift in Sources */,
+				252FFA7029CB9C130010C984 /* Cart.swift in Sources */,
 				67F19643284970E500008D82 /* DemoAppApp.swift in Sources */,
+				252FFA6C29CB93690010C984 /* Product.swift in Sources */,
+				252FFA6E29CB948C0010C984 /* ProductError.swift in Sources */,
+				252FFA7229CBA3E50010C984 /* ProductService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +280,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				67F19654284970E500008D82 /* DemoAppTests.swift in Sources */,
+				252FFA7529CBAE230010C984 /* ProductServiceTests.swift in Sources */,
+				252FFA7829CBB2530010C984 /* CartTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DemoApp/Source/Models/Cart.swift
+++ b/DemoApp/Source/Models/Cart.swift
@@ -1,0 +1,79 @@
+//
+//  File.swift
+//  DemoApp
+//
+//  MIT License
+//
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+
+actor Cart {
+    var items: [Item]
+
+    var count: Int {
+        get async {
+            var count = 0
+
+            for item in items {
+                count += await item.quantity
+            }
+
+            return count
+        }
+    }
+
+    init(items: [Item]) {
+        self.items = items
+    }
+
+    func add(_ product: Product, quantity: Int = 1) async {
+        // If we already have the product, increase the quantity
+        if let existingItem = items.first(where: { $0.product == product }) {
+            await existingItem.setQuantity(existingItem.quantity + quantity)
+        } else {
+            let item = Item(product: product, quantity: quantity)
+            items.append(item)
+        }
+    }
+
+    func remove(product: Product) {
+        items.removeAll { item in
+            item.product == product
+        }
+    }
+}
+
+extension Cart {
+    actor Item {
+        let product: Product
+        var quantity: Int
+
+        init(product: Product, quantity: Int) {
+            self.product = product
+            self.quantity = quantity
+        }
+
+        func setQuantity(_ newQuantity: Int) {
+            quantity = newQuantity
+        }
+    }
+}

--- a/DemoApp/Source/Models/Product.swift
+++ b/DemoApp/Source/Models/Product.swift
@@ -1,10 +1,10 @@
 //
-//  DemoAppApp.swift
+//  Product.swift
 //  DemoApp
 //
 //  MIT License
 //
-//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -24,13 +24,21 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-@main
-struct DemoAppApp: App {
-    var body: some Scene {
-        WindowGroup {
-            Text("Check the unit tests to see Gauntlet in action")
-        }
-    }
+struct Product: Equatable, Identifiable {
+    let name: String
+    let id: String
+}
+
+extension Product {
+    static let all = [
+        Product(name: "Allspice", id: "1234"),
+        Product(name: "Bread", id: "2345"),
+        Product(name: "Carrot", id: "3456"),
+        Product(name: "Date", id: "4567"),
+        Product(name: "Eggs", id: "5678"),
+        Product(name: "Flour", id: "6789"),
+        Product(name: "Grapes", id: "7890")
+    ]
 }

--- a/DemoApp/Source/Models/ProductError.swift
+++ b/DemoApp/Source/Models/ProductError.swift
@@ -1,10 +1,10 @@
 //
-//  DemoAppApp.swift
+//  ProductError.swift
 //  DemoApp
 //
 //  MIT License
 //
-//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -24,13 +24,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-@main
-struct DemoAppApp: App {
-    var body: some Scene {
-        WindowGroup {
-            Text("Check the unit tests to see Gauntlet in action")
-        }
-    }
+enum ProductError: Error, Equatable {
+    case unableToLoadProducts
+    case noProductForID(String)
 }

--- a/DemoApp/Source/Models/ProductService.swift
+++ b/DemoApp/Source/Models/ProductService.swift
@@ -1,10 +1,10 @@
 //
-//  ContentView.swift
+//  ProductService.swift
 //  DemoApp
 //
 //  MIT License
 //
-//  Copyright (c) [2020] The Kroger Co. All rights reserved.
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -24,17 +24,26 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-struct ContentView: View {
-    var body: some View {
-        Text("Hello, world!")
-            .padding()
+struct ProductService {
+    private let allProducts = Product.all
+
+    func getAllProducts(queue: DispatchQueue, completion: @escaping (Result<[Product], Error>) -> Void) {
+        queue.async {
+            completion(.success(allProducts))
+        }
     }
-}
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+    func getProduct(id: String, queue: DispatchQueue, completion: @escaping (Result<Product, Error>) -> Void) {
+        let result = Result {
+            guard let product = allProducts.first(where: { $0.id == id }) else { throw ProductError.noProductForID(id) }
+
+            return product
+        }
+
+        queue.async {
+            completion(result)
+        }
     }
 }

--- a/DemoApp/Tests/CartTests.swift
+++ b/DemoApp/Tests/CartTests.swift
@@ -1,0 +1,90 @@
+//
+//  CartTests.swift
+//  DemoApp
+//
+//  MIT License
+//
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+@testable import DemoApp
+import Foundation
+import Gauntlet
+import XCTest
+
+class CartTestCase: XCTestCase {
+    func testAddProducts() async {
+        // Given
+        let cart = Cart(items: [])
+        let firstProduct = Product(name: "first", id: "1111")
+        let secondProduct = Product(name: "second", id: "2222")
+
+        // When
+        await cart.add(firstProduct)
+        await cart.add(secondProduct, quantity: 2)
+
+        // Then
+        await Assert(that: await cart.count).isEqualTo(3)
+        await Assert(that: await cart.items)
+            .hasCount(2)
+            .then { items in
+                let firstItem = items[0]
+                let secondItem = items[1]
+
+                await Assert(that: await firstItem.product).isEqualTo(firstProduct)
+                await Assert(that: await firstItem.quantity).isEqualTo(1)
+
+                await Assert(that: await secondItem.product).isEqualTo(secondProduct)
+                await Assert(that: await secondItem.quantity).isEqualTo(2)
+            }
+    }
+
+    func testReaddingProduct() async {
+        // Given
+        let cart = Cart(items: [])
+        let product = Product(name: "Halibut", id: "12345")
+
+        // When
+        await cart.add(product)
+        await cart.add(product, quantity: 4)
+
+        // Then
+        await Assert(that: await cart.count).isEqualTo(5)
+        await Assert(that: await cart.items).hasCount(1)
+    }
+
+    func testRemoveProduct() async {
+        // Given
+        let productToRemove = Product(name: "Some Product", id: "12345")
+        let cart = Cart(
+            items: [
+                Cart.Item(product: productToRemove, quantity: 5),
+                Cart.Item(product: Product(name: "Other Product", id: "54321"), quantity: 1)
+            ]
+        )
+
+        // When
+        await cart.remove(product: productToRemove)
+
+        // Then
+        await Assert(that: await cart.count).isEqualTo(1)
+        await Assert(that: await cart.items).hasCount(1)
+    }
+}

--- a/DemoApp/Tests/CartTests.swift
+++ b/DemoApp/Tests/CartTests.swift
@@ -42,17 +42,17 @@ class CartTestCase: XCTestCase {
 
         // Then
         Assert(that: await cart.count).isEqualTo(3)
-        await Assert(async: await cart.items)
+        await Assert(that: await cart.items)
             .hasCount(2)
             .asyncThen { items in
                 let firstItem = items[0]
                 let secondItem = items[1]
 
-                await Assert(async: await firstItem.product).isEqualTo(firstProduct)
-                await Assert(async: await firstItem.quantity).isEqualTo(1)
+                Assert(that: await firstItem.product).isEqualTo(firstProduct)
+                Assert(that: await firstItem.quantity).isEqualTo(1)
 
-                await Assert(async: await secondItem.product).isEqualTo(secondProduct)
-                await Assert(async: await secondItem.quantity).isEqualTo(2)
+                Assert(that: await secondItem.product).isEqualTo(secondProduct)
+                Assert(that: await secondItem.quantity).isEqualTo(2)
             }
     }
 
@@ -66,8 +66,8 @@ class CartTestCase: XCTestCase {
         await cart.add(product, quantity: 4)
 
         // Then
-        await Assert(async: await cart.count).isEqualTo(5)
-        await Assert(async: await cart.items).hasCount(1)
+        Assert(that: await cart.count).isEqualTo(5)
+        Assert(that: await cart.items).hasCount(1)
     }
 
     func testRemoveProduct() async {
@@ -84,7 +84,7 @@ class CartTestCase: XCTestCase {
         await cart.remove(product: productToRemove)
 
         // Then
-        await Assert(async: await cart.count).isEqualTo(1)
-        await Assert(async: await cart.items).hasCount(1)
+        Assert(that: await cart.count).isEqualTo(1)
+        Assert(that: await cart.items).hasCount(1)
     }
 }

--- a/DemoApp/Tests/CartTests.swift
+++ b/DemoApp/Tests/CartTests.swift
@@ -41,18 +41,18 @@ class CartTestCase: XCTestCase {
         await cart.add(secondProduct, quantity: 2)
 
         // Then
-        await Assert(that: await cart.count).isEqualTo(3)
-        await Assert(that: await cart.items)
+        Assert(that: await cart.count).isEqualTo(3)
+        await Assert(async: await cart.items)
             .hasCount(2)
-            .then { items in
+            .asyncThen { items in
                 let firstItem = items[0]
                 let secondItem = items[1]
 
-                await Assert(that: await firstItem.product).isEqualTo(firstProduct)
-                await Assert(that: await firstItem.quantity).isEqualTo(1)
+                await Assert(async: await firstItem.product).isEqualTo(firstProduct)
+                await Assert(async: await firstItem.quantity).isEqualTo(1)
 
-                await Assert(that: await secondItem.product).isEqualTo(secondProduct)
-                await Assert(that: await secondItem.quantity).isEqualTo(2)
+                await Assert(async: await secondItem.product).isEqualTo(secondProduct)
+                await Assert(async: await secondItem.quantity).isEqualTo(2)
             }
     }
 
@@ -66,8 +66,8 @@ class CartTestCase: XCTestCase {
         await cart.add(product, quantity: 4)
 
         // Then
-        await Assert(that: await cart.count).isEqualTo(5)
-        await Assert(that: await cart.items).hasCount(1)
+        await Assert(async: await cart.count).isEqualTo(5)
+        await Assert(async: await cart.items).hasCount(1)
     }
 
     func testRemoveProduct() async {
@@ -84,7 +84,7 @@ class CartTestCase: XCTestCase {
         await cart.remove(product: productToRemove)
 
         // Then
-        await Assert(that: await cart.count).isEqualTo(1)
-        await Assert(that: await cart.items).hasCount(1)
+        await Assert(async: await cart.count).isEqualTo(1)
+        await Assert(async: await cart.items).hasCount(1)
     }
 }

--- a/DemoApp/Tests/DemoAppTests.swift
+++ b/DemoApp/Tests/DemoAppTests.swift
@@ -30,6 +30,8 @@ import GauntletLegacy
 import XCTest
 
 class DemoAppTests: XCTestCase {
+
+    // This test validates that the DemoApp is correctly importing both the Gauntlet and GauntletLegacy modules.
     func testExample() throws {
         // Given, When
         let result: Result<String, Error> = .success("Hello")

--- a/DemoApp/Tests/ProductServiceTests.swift
+++ b/DemoApp/Tests/ProductServiceTests.swift
@@ -1,0 +1,108 @@
+//
+//  ProductServiceTests.swift
+//  DemoApp
+//
+//  MIT License
+//
+//  Copyright (c) [2023] The Kroger Co. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+@testable import DemoApp
+import Foundation
+import Gauntlet
+import XCTest
+
+class ProductServiceTestCase: XCTestCase {
+    private let queue = DispatchQueue(label: "com.krogerco.DemoAppTests.ProductService")
+
+    // Asserts that the provider will return a success when getting all products.
+    func testGetAllProducts() {
+        // Given
+        let service = ProductService()
+        var result: Result<[Product], Error>?
+        let expectation = self.expectation(description: "The getAllProducts completion will be called")
+
+        // When
+        service.getAllProducts(queue: queue) { [self] receivedResult in
+            result = receivedResult
+            Assert(that: queue).isTheCurrentQueue()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+
+        Assert(that: result)
+            .isNotNil()
+            .isSuccess()
+            .hasCount(7)
+            .then { products in
+                Assert(that: products[0]).isEqualTo(Product(name: "Allspice", id: "1234"))
+            }
+    }
+
+    // Asserts that the provider will return a success result when a product is requested for a known id.
+    func testGetProductSuccess() {
+        // Given
+        let service = ProductService()
+        var result: Result<Product, Error>?
+        let expectation = self.expectation(description: "The getAllProducts completion will be called")
+
+        // When
+        service.getProduct(id: "5678", queue: queue) { [self] receivedResult in
+            result = receivedResult
+            Assert(that: queue).isTheCurrentQueue()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        let expectedProduct = Product(name: "Eggs", id: "5678")
+
+        Assert(that: result)
+            .isNotNil()
+            .isSuccess()
+            .isEqualTo(expectedProduct)
+    }
+
+    // Asserts that the provider will return a failure result when a product is requested for an id it doesn't know about.
+    func testGetProductFailure() {
+        // Given
+        let service = ProductService()
+        var result: Result<Product, Error>?
+        let expectation = self.expectation(description: "The getAllProducts completion will be called")
+
+        // When
+        service.getProduct(id: "invalid-id", queue: queue) { [self] receivedResult in
+            result = receivedResult
+            Assert(that: queue).isTheCurrentQueue()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+
+        Assert(that: result)
+            .isNotNil()
+            .isFailure()
+            .isOfType(ProductError.self)
+            .isEqualTo(.noProductForID("invalid-id"))
+    }
+}

--- a/Source/Gauntlet/Assertion/Assertion.swift
+++ b/Source/Gauntlet/Assertion/Assertion.swift
@@ -236,16 +236,4 @@ extension Assertion {
     {
         self.init(result: .pass(value), name: name, filePath: filePath, lineNumber: lineNumber, recorder: recorder, isRoot: isRoot)
     }
-
-    convenience init(
-        expression: () async -> Value,
-        name: String,
-        filePath: String,
-        lineNumber: Int,
-        recorder: FailureRecorder,
-        isRoot: Bool) async
-    {
-        let value = await expression()
-        self.init(result: .pass(value), name: name, filePath: filePath, lineNumber: lineNumber, recorder: recorder, isRoot: isRoot)
-    }
 }

--- a/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
+++ b/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
@@ -57,31 +57,6 @@ extension XCTestCase {
         )
     }
 
-    /// Creates an ``Assertion`` on the specified `async` expression.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to assert on.
-    ///   - filePath: The path to the source file in which the assertion exists. This should not be provided manually.
-    ///   - lineNumber: The line number of the asertion. This should not be provided manually.
-    public func Assert<T: Sendable>(
-        async expression: @autoclosure () async -> T,
-        filePath: String = #filePath,
-        lineNumber: Int = #line)
-        async -> Assertion<T>
-    {
-        let typeName = String(describing: T.self)
-        let name = "Assert(that: \(typeName))"
-
-        return await Assertion(
-            expression: expression,
-            name: name,
-            filePath: filePath,
-            lineNumber: lineNumber,
-            recorder: self,
-            isRoot: true
-        )
-    }
-
     // MARK: - Throwing
 
     /// Creates an ``Assertion`` on the specified throwing expression.

--- a/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
+++ b/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
@@ -64,7 +64,7 @@ extension XCTestCase {
     ///   - filePath: The path to the source file in which the assertion exists. This should not be provided manually.
     ///   - lineNumber: The line number of the asertion. This should not be provided manually.
     public func Assert<T: Sendable>(
-        that expression: @autoclosure () async -> T,
+        async expression: @autoclosure () async -> T,
         filePath: String = #filePath,
         lineNumber: Int = #line)
         async -> Assertion<T>
@@ -116,7 +116,7 @@ extension XCTestCase {
     ///   - filePath: The path to the source file in which the assertion exists. This should not be provided manually.
     ///   - lineNumber: The line number of the asertion. This should not be provided manually.
     public func Assert<T>(
-        throwingExpression expression: @escaping @autoclosure () async throws -> T,
+        asyncThrowingExpression expression: @escaping @autoclosure () async throws -> T,
         filePath: String = #filePath,
         lineNumber: Int = #line)
         async -> Assertion<AsyncThrowableExpression<T>>

--- a/Source/Gauntlet/Operators/ThenOperators.swift
+++ b/Source/Gauntlet/Operators/ThenOperators.swift
@@ -48,8 +48,8 @@ extension Assertion {
     /// Errors thrown by the closure will result in an assertion failure.
     ///
     /// - Parameter closure: A closure to ge called if the ``Assertion`` is a success.
-    public func then(line: Int = #line, _ closure: (Value) async throws -> Void) async {
-        let _: Assertion<Void> = await asyncEvaluate(name: "then", lineNumber: line) { value in
+    public func asyncThen(line: Int = #line, _ closure: (Value) async throws -> Void) async {
+        let _: Assertion<Void> = await asyncEvaluate(name: "asyncThen", lineNumber: line) { value in
             do {
                 try await closure(value)
                 return .pass

--- a/Source/Gauntlet/Operators/ThenOperators.swift
+++ b/Source/Gauntlet/Operators/ThenOperators.swift
@@ -42,4 +42,20 @@ extension Assertion {
             }
         }
     }
+
+    /// Terminates an assertion by calling the provided async closure if the ``Assertion`` is a success.
+    ///
+    /// Errors thrown by the closure will result in an assertion failure.
+    ///
+    /// - Parameter closure: A closure to ge called if the ``Assertion`` is a success.
+    public func then(line: Int = #line, _ closure: (Value) async throws -> Void) async {
+        let _: Assertion<Void> = await asyncEvaluate(name: "then", lineNumber: line) { value in
+            do {
+                try await closure(value)
+                return .pass
+            } catch {
+                return .fail(thrownError: error)
+            }
+        }
+    }
 }

--- a/Tests/GauntletTests/Assertion/AssertionInitializationTests.swift
+++ b/Tests/GauntletTests/Assertion/AssertionInitializationTests.swift
@@ -137,41 +137,6 @@ class AssertionTestCase: XCTestCase {
         XCTAssert(recorder.recordedFailures.isEmpty)
     }
 
-    /// The async value initializer should have a `success` result, store the provided values, and not record any failures to the recorder.
-    func testAsyncValueInit() async {
-        // Given
-        let recorder = MockFailureRecorder()
-        let name = "Some Assertion Name"
-        let filePath = "/some/file/path"
-        let lineNumber = 3412
-        let isRoot = true
-        let model = AsyncModel()
-
-        // When
-        let assertion = await Assertion(
-            expression: { await model.getValue() },
-            name: name,
-            filePath: filePath,
-            lineNumber: lineNumber,
-            recorder: recorder,
-            isRoot: isRoot
-        )
-
-        // Then
-        if case let .pass(resultValue) = assertion.result {
-            XCTAssertEqual(resultValue, "async-value")
-        } else {
-            XCTFail("Result is not a pass")
-        }
-
-        XCTAssertEqual(assertion.name, name)
-        XCTAssertEqual(assertion.filePath, filePath)
-        XCTAssertEqual(assertion.lineNumber, lineNumber)
-        XCTAssert(assertion.recorder is MockFailureRecorder)
-        XCTAssertEqual(assertion.isRoot, isRoot)
-        XCTAssert(recorder.recordedFailures.isEmpty)
-    }
-
     // MARK: - Deinit
 
     /// If an `Assertion` is root and was created on a value but no assertions were ever evaluated by the time it deiniitialized the assertion should record a failure

--- a/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
+++ b/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
@@ -52,7 +52,7 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         let model = AsyncModel()
 
         // When, Then
-        await Assert(async: await model.getValue()).pass()
+        Assert(that: await model.getValue()).pass()
     }
 
     func testFailingLiveAsyncValueAssert() async {
@@ -61,7 +61,7 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         XCTExpectFailure("This assertion should generate a failure")
 
         // When, Then
-        await Assert(async: await model.getValue()).fail()
+        Assert(that: await model.getValue()).fail()
     }
 
     // MARK: - Throwable Assert

--- a/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
+++ b/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
@@ -52,7 +52,7 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         let model = AsyncModel()
 
         // When, Then
-        await Assert(that: await model.getValue()).pass()
+        await Assert(async: await model.getValue()).pass()
     }
 
     func testFailingLiveAsyncValueAssert() async {
@@ -61,7 +61,7 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         XCTExpectFailure("This assertion should generate a failure")
 
         // When, Then
-        await Assert(that: await model.getValue()).fail()
+        await Assert(async: await model.getValue()).fail()
     }
 
     // MARK: - Throwable Assert
@@ -90,7 +90,7 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         let model = ThrowingAsyncModel(result: .success(""))
 
         // When, Then
-        await Assert(throwingExpression: try await model.getValue()).pass()
+        await Assert(asyncThrowingExpression: try await model.getValue()).pass()
     }
 
     func testFailingLiveAsyncThrowableAssert() async {
@@ -99,6 +99,6 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         XCTExpectFailure("This assertion should generate a failure")
 
         // When, Then
-        await Assert(throwingExpression: try await model.getValue()).fail()
+        await Assert(asyncThrowingExpression: try await model.getValue()).fail()
     }
 }

--- a/Tests/GauntletTests/Extensions/XCTestCaseExtensionsTests.swift
+++ b/Tests/GauntletTests/Extensions/XCTestCaseExtensionsTests.swift
@@ -162,13 +162,13 @@ class XCTestCaseExtensionsTestCase: XCTestCase {
         XCTAssertTrue(assertion.isRoot)
     }
 
-    /// Ensure async assertions created via `Assert(that: )` are correctly configured.
-    func testAssertAsyncInitializer() async {
+    /// Ensure assertions created via `Assert(that: )` can accept async values as the parameter and are correctly configured.
+    func testAssertInitializerAcceptsAsyncParameterCall() async {
         // Given
         let model = AsyncModel()
 
         // When
-        let assertion = await Assert(that: await model.getValue(), filePath: "some/file", lineNumber: 123)
+        let assertion = Assert(that: await model.getValue(), filePath: "some/file", lineNumber: 123)
 
         // Evaluate the assertion before leaving to prevent failures for not evaluating.
         defer { assertion.evaluate() }

--- a/Tests/GauntletTests/Extensions/XCTestCaseExtensionsTests.swift
+++ b/Tests/GauntletTests/Extensions/XCTestCaseExtensionsTests.swift
@@ -216,13 +216,13 @@ class XCTestCaseExtensionsTestCase: XCTestCase {
         XCTAssert(assertion.recorder as? Self === self)
     }
 
-    /// Ensure async throwing assertions created via `Assert(throwingExpression: )` are correctly configured.
+    /// Ensure async throwing assertions created via `Assert(asyncThrowingExpression: )` are correctly configured.
     func testAssertAsyncThrowingInitializer() async {
         // Given
         let model = ThrowingAsyncModel(result: .success("awaited-no-throw") )
 
         // When
-        let assertion = await Assert(throwingExpression: try await model.getValue(), filePath: "some/file", lineNumber: 123)
+        let assertion = await Assert(asyncThrowingExpression: try await model.getValue(), filePath: "some/file", lineNumber: 123)
 
         // Evaluate the assertion before leaving to prevent failures for not evaluating.
         defer { assertion.evaluate() }


### PR DESCRIPTION
### What:
- Fleshes out the demo app to include some models and example tests.
- Removes the unneeded Async initializers for Assertion.
- Adds an `asyncThen` closure.

### Why:
- The lacking demo app came up in sync, this fleshes it out with a couple example models and tests on those models to demonstrate a lot of Gauntlet in action. This includes an Actor to show how async code can be tested.
- The async initializers turned out to be completely unnecessary since it doesn't use an autoclosure. Async variants are only needed for throwing expressions and then closures.
- An `asyncThen` can be useful if you need to deal with additional async calls within a then, this seems like it will be a common thing to encounter when writing tests on Actors.

