### PR TITLE
Add a migration guide, link from the README.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules: # rule identifiers to exclude from running
   - opening_brace
   - nesting
   - function_body_length
+  - blanket_disable_command
 
 opt_in_rules: # some rules are only opt-in
   - anyobject_protocol
@@ -48,9 +49,7 @@ opt_in_rules: # some rules are only opt-in
   - prohibited_super_call
   - redundant_nil_coalescing
   - unneeded_parentheses_in_closure_argument
-  - unused_import
   - xct_specific_matcher
-
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Gauntlet provides a number of operators, and is designed to be extensible so tha
 
 Gauntlet has full DocC documentation. After adding to your project, `Build Documentation` to add to your documentation viewer.
 
+## Migration
+
+If you're migrating from Gauntlet 1.x check out the [migration guide](migration-guide.md) for details on how to upgrade to the new APIs.
+
 ## Communication
 
 If you have issues or suggestions, please open an issue on GitHub.

--- a/Source/Gauntlet/Documentation.docc/Documentation.md
+++ b/Source/Gauntlet/Documentation.docc/Documentation.md
@@ -29,6 +29,20 @@ Assert(that: result).isSuccess().isEqualTo("expected content")
 
 An operator is a function defined on an `Assertion` which performs validation on a value and then returns a new Assertion. If an operator's validation fails a test failure will be generated and no subsequent operators on that assertion will be evaluated. In the above example the `isSuccess()` operator validates that the result is a success and provides the associated success value in the returned Assertion.
 
+Gauntlet includes a `then` operator which can be used to break an Assertion out into more assertions that are only run when the original Assertion passes.
+
+```swift
+let model = Model()
+
+// When
+let result: Result<Content, Error> = model.loadContent()
+
+Assert(that: result).isSuccess().then { content in
+    Assert(that: content.id).isEqualTo("expected id")
+    ...
+}
+```
+
 Gauntlet includes a number of operators in the box, see ``Assertion`` for a listing of all the included operators. The API is also designed to be easily extensible, see <doc:creating-custom-operators> for details.
 
 ## Topics

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -1,0 +1,32 @@
+# Migration Guide
+
+## 1.x -> 2.x
+
+Gauntlet 2.0 includes a complete rethink of the APIs. To allow for a smooth and gradual transition to the new APIs the old APIs continue to exist, but have been moved to a new target `GauntletLegacy`. This was done to allow the old APIs to remain unchanged so that any tests using the old Gauntlet APIs can continue to run unaffected, and migrated to the new APIs over time.
+
+### Updating the Package Dependency
+
+First you'll need to update your package dependency to point to Gauntlet 2.0.0. After this you'll need to update your project to reference both the `Gauntlet` and `GauntletLegacy` targets. The process for this differs based on whether you're integrating into an App or a Framework with a Package file.
+
+#### Apps
+
+After updating to Gauntlet 2.0.0 navigate to your test target and select the Build Phases tab. Here you'll add the `GauntletLegacy` target to the Link Binary With Libraries phase, in addition to the `Gauntlet` target it should already be linking.
+
+#### Frameworks
+
+For a framework that uses a `Package.swift` file you'll need to update the dependencies section to link against both targets. Below is an example of a package's `testTarget` linking against both Gauntlet targets.
+
+```Swift
+.testTarget(
+    name: "MyFrameworkTests",
+    dependencies: [
+        "MyFramework",
+        .product(name: "Gauntlet", package: "Gauntlet"),
+        .product(name: "GauntletLegacy", package: "Gauntlet")
+    ],
+)
+```
+
+### Updating Imports
+
+Now that you're linking against the new target you'll nee to update exiting imports in your unit tests. Any code that imported `Gauntlet` should now import `GauntletLegacy` instead, as that target contains all of the old APIs. This should be the only change needed to get your tests building and running as they did previously. A find and replace of `import Gauntlet` to `import GauntletLegacy` across the project will be the easiest way to make this change.


### PR DESCRIPTION
### What:
Adds a migration guide to help users of the existing Gauntlet APIs update to the 2.0.0 release.