### PR TITLE
Add `contains` operator for collections

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ disabled_rules: # rule identifiers to exclude from running
   - blanket_disable_command
 
 opt_in_rules: # some rules are only opt-in
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation

--- a/Source/Gauntlet/Documentation.docc/assertion.md
+++ b/Source/Gauntlet/Documentation.docc/assertion.md
@@ -20,6 +20,7 @@ Operators for collections.
 - ``Assertion/isEmpty(line:)``
 - ``Assertion/isNotEmpty(line:)``
 - ``Assertion/hasCount(_:line:)``
+- ``Assertion/contains(_:line:)``
 
 ### Equality Operators
 Operators for equality comparisons.

--- a/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
+++ b/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
@@ -145,7 +145,7 @@ extension XCTestCase {
     /// will fail silently allowing  testing failure results of custom assertions without failing tests.
     ///
     /// The Assertion will have a result of `.success` with the provide value. It will have a name of `"TestAssertion"` and a line number of `0`
-    /// so that you can test you've provided the right values to ``Assertion/evaluate(name:lineNumber:_:)``.
+    /// so that you can test you've provided the right values to ``Assertion/evaluate(name:lineNumber:evaluator:)``.
     ///
     /// - Parameters:
     ///   - value: The initial value
@@ -169,7 +169,7 @@ extension XCTestCase {
     /// assertion is a success.
     ///
     /// The Assertion will have a result of `.failure` with a message. It will have a name of `"TestFailedAssertion"` and a line number of `0`
-    /// so that you can test you've provided the right values to ``Assertion/evaluate(name:lineNumber:_:)``.
+    /// so that you can test you've provided the right values to ``Assertion/evaluate(name:lineNumber:evaluator:)``.
     ///
     /// - Returns: An ``Assertion`` configured for testing with the specified value.
     public func TestFailedAssertion() -> Assertion<Void> {

--- a/Source/Gauntlet/Operators/CollectionOperators.swift
+++ b/Source/Gauntlet/Operators/CollectionOperators.swift
@@ -25,6 +25,8 @@
 
 import Foundation
 
+// MARK: - Empty
+
 extension Assertion where Value: Collection {
 
     /// Asserts that the collection has no items in it.
@@ -52,7 +54,11 @@ extension Assertion where Value: Collection {
             return .fail(message: "The collection is empty")
         }
     }
+}
 
+// MARK: - Count
+
+extension Assertion where Value: Collection {
     /// Asserts tha the collection has the expected number of items, providing the colelction.
     ///
     /// - Parameters:
@@ -65,6 +71,26 @@ extension Assertion where Value: Collection {
             if collection.count == expectedCount { return .pass(collection) }
 
             return .fail(message: "Count of \(collection.count) is not equal to the expected count \(expectedCount)")
+        }
+    }
+}
+
+// MARK: - Contains
+
+extension Assertion where Value: Collection, Value.Element: Equatable {
+
+    /// Asserts that the collection contains the expected item, providing the collection.
+    ///
+    /// - Parameters:
+    ///   - expectedValue: The value that's expected to be in the collection.
+    ///
+    /// - Returns: An ``Assertion`` containing the collection.
+    @discardableResult
+    public func contains<T>(_ expectedValue: T, line: Int = #line) -> Assertion<Value> where T == Value.Element {
+        evaluate(name: "contains", lineNumber: line) { collection in
+            if collection.contains(expectedValue) { return .pass(collection) }
+
+            return .fail(message: #"The collection does not contain "\#(expectedValue)""#)
         }
     }
 }

--- a/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
@@ -151,6 +151,23 @@ class CollectionOperatorsTestCase: XCTestCase {
             .isEqualTo(array)
     }
 
+    func testContainsArrayChainedSuccess() {
+        // Given
+        let array = ["alpha", "bravo", "charlie"]
+        let expectedLine = 645
+
+        // When
+        let assertion = TestAnAssertion(on: array)
+            .contains("alpha", line: 1)
+            .contains("bravo", line: 2)
+            .contains("charlie", line: expectedLine)
+
+        // Then
+        Assert(that: assertion)
+            .didPass(expectedName: "contains", expectedLine: expectedLine)
+            .isEqualTo(array)
+    }
+
     func testContainsArrayFailure() {
         // Given
         let array = ["alpha", "bravo", "charlie"]

--- a/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
@@ -137,7 +137,7 @@ class CollectionOperatorsTestCase: XCTestCase {
 
     // MARK: - Contains
 
-    func testContainsSuccess() {
+    func testContainsArraySuccess() {
         // Given
         let array = ["alpha", "bravo", "charlie"]
         let expectedLine = 645
@@ -151,9 +151,38 @@ class CollectionOperatorsTestCase: XCTestCase {
             .isEqualTo(array)
     }
 
-    func testContainsFailure() {
+    func testContainsArrayFailure() {
         // Given
         let array = ["alpha", "bravo", "charlie"]
+        let expectedLine = 465
+
+        // When
+        let assertion = TestAnAssertion(on: array).contains("delta", line: expectedLine)
+
+        // Then
+        Assert(that: assertion)
+            .didFail(expectedName: "contains", expectedLine: expectedLine)
+            .isMessage()
+            .isEqualTo(#"The collection does not contain "delta""#)
+    }
+
+    func testContainsSetSuccess() {
+        // Given
+        let array = Set(["alpha", "bravo", "charlie"])
+        let expectedLine = 645
+
+        // When
+        let assertion = TestAnAssertion(on: array).contains("bravo", line: expectedLine)
+
+        // Then
+        Assert(that: assertion)
+            .didPass(expectedName: "contains", expectedLine: expectedLine)
+            .isEqualTo(array)
+    }
+
+    func testContainsSetFailure() {
+        // Given
+        let array = Set(["alpha", "bravo", "charlie"])
         let expectedLine = 465
 
         // When

--- a/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
+++ b/Tests/GauntletTests/Operators/CollectionOperatorsTests.swift
@@ -134,4 +134,35 @@ class CollectionOperatorsTestCase: XCTestCase {
             .isMessage()
             .isEqualTo("Count of 2 is not equal to the expected count 5")
     }
+
+    // MARK: - Contains
+
+    func testContainsSuccess() {
+        // Given
+        let array = ["alpha", "bravo", "charlie"]
+        let expectedLine = 645
+
+        // When
+        let assertion = TestAnAssertion(on: array).contains("bravo", line: expectedLine)
+
+        // Then
+        Assert(that: assertion)
+            .didPass(expectedName: "contains", expectedLine: expectedLine)
+            .isEqualTo(array)
+    }
+
+    func testContainsFailure() {
+        // Given
+        let array = ["alpha", "bravo", "charlie"]
+        let expectedLine = 465
+
+        // When
+        let assertion = TestAnAssertion(on: array).contains("delta", line: expectedLine)
+
+        // Then
+        Assert(that: assertion)
+            .didFail(expectedName: "contains", expectedLine: expectedLine)
+            .isMessage()
+            .isEqualTo(#"The collection does not contain "delta""#)
+    }
 }


### PR DESCRIPTION
### What:
Adds a new `contains` operator for `Collection`s that have an `Equatable` value.

### Why:
Provides an assertion that corresponds to a commonly used function on collections. This operator returns the original collection so multiple calls can be chained to validate multiple distinct values in cases where the overall contents and order of the collection aren't important for the test.

```swift
Assert(that: somearray)
    .contains("foo")
    .contains("bar")
```

### How:
Implemented a new operator on any `Collection` with an `Equatable` element that calls through to `contains` on the collection.

### Testing Notes
Included tests for both `Array` and `Set`. If there are any other useful collections to validate this with let me know.
