### PR TITLE
Mark Assert(failure:) as having a discardableResult.

### DIFF
--- a/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
+++ b/Source/Gauntlet/Extensions/XCTestCaseExtensions.swift
@@ -117,6 +117,7 @@ extension XCTestCase {
     ///   - message: A description of the failure.
     ///   - filePath: The path to the source file in which the assertion exists. This should not be provided manually.
     ///   - lineNumber: The line number of the asertion. This should not be provided manually.
+    @discardableResult
     public func Assert(
         failure message: String,
         filePath: String = #filePath,

--- a/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
+++ b/Tests/GauntletTests/Extensions/XCTestCaseExtensionsLiveTests.swift
@@ -101,4 +101,14 @@ class XCTestCaseExtensionsLiveTestCase: XCTestCase {
         // When, Then
         await Assert(asyncThrowingExpression: try await model.getValue()).fail()
     }
+
+    // MARK: - Failure Assert
+
+    func testFailureAssertion() {
+        // Given
+        XCTExpectFailure("Assert(failure:) should cause a failure")
+
+        // When, Then
+        Assert(failure: "This should fail and not generate a warning for unused result")
+    }
 }


### PR DESCRIPTION
### What:
Updates `Assert(failure: )` to be marked as having a `discardableResult`.

### Why:
This function is meant to function like `XCTFail(...)` to generate a failure. When you use it this way now it generates a warning as the returned value isn't used.

### Testing Notes
Added a test to the Live tests section to validate this builds cleanly without a warning when used as intended.